### PR TITLE
#86 メインセットのUI調整

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,36 +1,38 @@
 AllCops:
-    TargetRubyVersion: 2.6.3
-    Exclude:
-        - 'db/**/*'
-        - 'config/**/*'
-        - 'script/**/*'
-        - '.git/**/*'
-        - 'public/**/*'
-        - 'log/**/*'
-        - 'tmp/**/*'
-        - 'test/**/*'
-        - 'spec/**/*'
-        - 'node_modules/**/*'
-        - 'bin/**'
-        - 'Gemfile'
-        - 'Rakefile'
-        - 'app/channels/**/*'
-        - 'vendor/**/*'
+  TargetRubyVersion: 2.6.3
+  Exclude:
+    - "db/**/*"
+    - "config/**/*"
+    - "script/**/*"
+    - ".git/**/*"
+    - "public/**/*"
+    - "log/**/*"
+    - "tmp/**/*"
+    - "test/**/*"
+    - "spec/**/*"
+    - "node_modules/**/*"
+    - "bin/**"
+    - "Gemfile"
+    - "Rakefile"
+    - "app/channels/**/*"
+    - "vendor/**/*"
 Layout/IndentationWidth:
-    Enabled: false
+  Enabled: false
 Style/FrozenStringLiteralComment:
-    Enabled: false
+  Enabled: false
 # 日本語のコメントアウトを許可する
 Style/AsciiComments:
-    Enabled: false
+  Enabled: false
 # クラスを継承する前にコメントを書く必要はない
 Style/Documentation:
-    Enabled: false
+  Enabled: false
 Layout/LineLength:
-    Enabled: false
+  Enabled: false
 Style/ClassAndModuleChildren:
-    Enabled: false
+  Enabled: false
 Metrics/AbcSize:
-    Enabled: false
+  Enabled: false
 Style/MutableConstant:
-    Enabled: false
+  Enabled: false
+StringLiterals:
+  EnforcedStyle: single_quotes

--- a/app/assets/stylesheets/training_record.scss
+++ b/app/assets/stylesheets/training_record.scss
@@ -13,9 +13,9 @@ $main_color: orange;
 
 $icon_color: #000;
 
-// #index {
-//     margin-top: 50px;
-// }
+.mainMark i {
+    color: $main_color;
+}
 
 .record_index .record_list {
     display: flex;
@@ -25,10 +25,6 @@ $icon_color: #000;
         flex-direction: column;
     }
 }
-
-// section > .record_index {
-//     margin-top: 80px;
-// }
 
 .record_index li img {
     width: 100%;
@@ -218,6 +214,9 @@ $icon_color: #000;
                 padding: 20px 25px;
                 background: #fff;
                 border: 5px ridge $main_color;
+                @include sp {
+                    padding: 20px 20px;
+                }
                 select {
                     outline:none;
                     -moz-appearance: none;
@@ -248,10 +247,13 @@ $icon_color: #000;
                 input[type="number"] {
                     width: 60px;
                     height: 35px;
-                    margin-right: 15px;
+                    margin-right: 12px;
                     padding: 5px;
                     font-size: 14px;
                     border:1px solid $main_color;
+                    @include sp {
+                        width: 45px;
+                    }
                 }
                 table {
                     margin-top: 15px;
@@ -278,8 +280,24 @@ $icon_color: #000;
                             transition: 0.3s;
                         }
                     }
+                    .main {
+                        font-size: 14px;
+                        @include sp {
+                            font-size: 10px;
+                        }
+                    }
                     input[type="checkbox"] {
                         -webkit-appearance: checkbox;
+                        font-size: 30px;
+                        @include sp {
+                            font-size: 12px;
+                        }
+                    }
+                    .removeIcon {
+                        padding-left: 25px;
+                        @include sp {
+                            padding-left: 12px;
+                        }
                     }
                 }
             }

--- a/app/controllers/training_record_controller.rb
+++ b/app/controllers/training_record_controller.rb
@@ -82,12 +82,12 @@ class TrainingRecordController < ApplicationController
 
   def create_training_record_params
     # 小テーブルの種目テーブルも同時にパラメータ取得
-    params.require(:training_record).permit(:comment, :picture, event_attributes: [:part, :name, :_destroy, set_datum_attributes: %i[weight rep set main _destroy]]).merge(user_id: current_user.id)
+    params.require(:training_record).permit(:comment, :picture, event_attributes: [:part, :name, :_destroy, set_datum_attributes: %i[weight rep set main renewal _destroy]]).merge(user_id: current_user.id)
   end
 
   def update_training_record_params
       # 小テーブルの種目テーブルも同時にパラメータ取得
-      params.require(:training_record).permit(:comment, :picture, event_attributes: [:id, :part, :name, :_destroy, set_datum_attributes: %i[id weight rep set main _destroy]]).merge(user_id: current_user.id)
+      params.require(:training_record).permit(:comment, :picture, event_attributes: [:id, :part, :name, :_destroy, set_datum_attributes: %i[id weight rep set main renewal _destroy]]).merge(user_id: current_user.id)
   end
 
   def menu_name_params

--- a/app/javascript/packs/ch.js
+++ b/app/javascript/packs/ch.js
@@ -1,58 +1,62 @@
-import Vue from 'vue/dist/vue.esm.js'
-import { Bar } from 'vue-chartjs'
-import axios from 'axios'
-    const urlItems = location.search.split('&')
-    const userID = urlItems[0].split('=')[1]
-    const eventName = urlItems[1].split('=')[1]
-    const axiosGetUrl = "/api/events/?user_id=" + userID+"&event_name=" + eventName
-    var app = new Vue({
-        el: '#chart',
+import Vue from "vue/dist/vue.esm.js";
+import { Bar } from "vue-chartjs";
+import axios from "axios";
+const urlItems = location.search.split("&");
+const userID = urlItems[0].split("=")[1];
+const eventName = urlItems[1].split("=")[1];
+const axiosGetUrl =
+  "/api/events/?user_id=" + userID + "&event_name=" + eventName;
+var app = new Vue({
+  el: "#chart",
+  data: {
+    labels: [],
+    allData: [],
+    mainData: [],
+    upData: [],
+    loading: true,
+  },
+  methods: {
+    displayGraph: function() {
+      var ctx = document.getElementById("myChart").getContext("2d");
+      var myChart = new Chart(ctx, {
+        type: "bar",
         data: {
-            labels: [],
-            allData: [],
-            mainData: [],
-            upData: [],
-            loading: true
-        },
-        methods: {
-            displayGraph: function(){
-                var ctx = document.getElementById('myChart').getContext('2d');
-                var myChart = new Chart(ctx, {
-                type: 'bar',
-                data: {
-                    labels: this.labels,
-                    datasets: [{
-                        label: '重量の遷移',
-                        data: this.allData,
-                        backgroundColor:'rgba(231,130,32,0.9)'
-                    }]
-                },
-                options: {
-                    maintainAspectRatio: false,
-                    scales: {
-                        yAxes: [
-                            {
-                                ticks: {
-                                    beginAtZero: true,
-                                    min: 0
-                                }
-                            }
-                        ]
-                    }
-                }
-                });
+          labels: this.labels,
+          datasets: [
+            {
+              label: "重量の遷移",
+              data: this.allData,
+              backgroundColor: "rgba(231,130,32,0.9)",
             },
+          ],
         },
-        mounted: function(){
-            axios
-                .get(axiosGetUrl)
-                .then(response=>{
-                    console.log(response);
-                    this.allData = response.data.weight.map(weight=>weight.weight);
-                    this.labels = response.data.weight.map(weight=>weight.created_at);
-                    this.loading = false;
-                    this.displayGraph();
-                    }
-                )
-        }
+        options: {
+          maintainAspectRatio: false,
+          scales: {
+            yAxes: [
+              {
+                ticks: {
+                  beginAtZero: true,
+                  min: 0,
+                },
+              },
+            ],
+          },
+        },
       });
+    },
+    updateGraph: function() {
+      this.allData = [10, 20, 30, 40, 50];
+      console.log("aaaa");
+    },
+  },
+  mounted: function() {
+    axios.get(axiosGetUrl).then((response) => {
+      console.log(response);
+      this.allData = response.data.weight.map((weight) => weight.weight);
+      this.labels = response.data.weight.map((weight) => weight.created_at);
+      this.loading = false;
+      this.displayGraph();
+    });
+  },
+});

--- a/app/views/api/training_record/user_event.json.jbuilder
+++ b/app/views/api/training_record/user_event.json.jbuilder
@@ -1,11 +1,8 @@
-# json.set! :training_record do
-# トレーニング記録
 json.weight do
-        json.array! @event do |event|
-            # json.(event, :weight,:created_at)
-            json.weight event.weight
-            json.main event.main
-            json.created_at event.created_at.to_s(:date)
-        end
+  json.array! @event do |event|
+    json.weight event.weight
+    json.main event.main
+    json.renewal event.renewal
+    json.created_at event.created_at.to_s(:date)
+  end
 end
-# end

--- a/app/views/shared/_record.html.erb
+++ b/app/views/shared/_record.html.erb
@@ -34,7 +34,9 @@
                                     <li><%= set.rep %>レップ</li>
                                     <li><%= set.set %>セット</li>
                                     <% if set.main %>
-                                    <li class="mainMark">メインセット</li>
+                                    <li class="mainMark">
+                                        <%= icon("fas", "star") %>
+                                    </li>
                                     <% end %>
                                 </ul>
                             <% end %>

--- a/app/views/shared/_record.html.erb
+++ b/app/views/shared/_record.html.erb
@@ -1,68 +1,73 @@
 <li class="record listItemDecorated">
-    <dl class="title">
-        <dt class="username">
-            <% user_id = record.user_id %>
-            <% user = User.find_by(id: user_id) %>
-            <% if user.picture.present? %>
-                <%=link_to "/users/#{user_id}" do %>
-                    <%= image_tag user.picture.url, class:"user_image" %>
-                        <%= user.name %>
-                <% end %>
-            <% else %>
-                <%= link_to "/users/#{user_id}" do %>
-                    <%= image_tag ('noicon.png'), class:"user_image" %>
-                    <%= user.name %>
-                <% end %>
-            <% end %>
-        </dt>
-        <dd class="date"><%= time_ago_in_words(record.created_at) %>前</dd>
-    </dl>
-    <div class="recordContents">
-        <div class="comment">
-            <%= record.comment %>
-        </div>
-        <div class="event">
-            <ol>
-                <% record.event.each do |item| %>
-                <li>
-                    <dl>
-                        <dt><%= link_to "#{item.name}", "/records/event/#{item.name}" %></dt>
-                        <dd>
-                            <% item.set_datum.each do |set| %>
-                                <ul class="set_list">
-                                    <li><%= weight_change(set.weight) %>kg</li>
-                                    <li><%= set.rep %>レップ</li>
-                                    <li><%= set.set %>セット</li>
-                                    <% if set.main %>
-                                    <li class="mainMark">
-                                        <%= icon("fas", "star") %>
-                                    </li>
-                                    <% end %>
-                                </ul>
-                            <% end %>
-                        </dd>
-                    </dl>
+  <dl class="title">
+    <dt class="username">
+      <% user_id = record.user_id %>
+      <% user = User.find_by(id: user_id) %>
+      <% if user.picture.present? %>
+      <%=link_to "/users/#{user_id}" do %>
+      <%= image_tag user.picture.url, class:"user_image" %>
+      <%= user.name %>
+      <% end %>
+      <% else %>
+      <%= link_to "/users/#{user_id}" do %>
+      <%= image_tag ('noicon.png'), class:"user_image" %>
+      <%= user.name %>
+      <% end %>
+      <% end %>
+    </dt>
+    <dd class="date"><%= time_ago_in_words(record.created_at) %>前</dd>
+  </dl>
+  <div class="recordContents">
+    <div class="comment">
+      <%= record.comment %>
+    </div>
+    <div class="event">
+      <ol>
+        <% record.event.each do |item| %>
+        <li>
+          <dl>
+            <dt><%= link_to "#{item.name}", "/records/event/#{item.name}" %></dt>
+            <dd>
+              <% item.set_datum.each do |set| %>
+              <ul class="set_list">
+                <li><%= weight_change(set.weight) %>kg</li>
+                <li><%= set.rep %>レップ</li>
+                <li><%= set.set %>セット</li>
+                <% if set.main %>
+                <li class="mainMark">
+                  <%= icon('fas', 'star') %>
                 </li>
                 <% end %>
-            </ol>
-        </div>
-        <% if record.picture? %>
-        <div class="picture">
-            <%= image_tag record.picture.url %>
-        </div>
+                <% if set.renewal %>
+                <li class="renewalMark">
+                  <%= icon('fas', 'smile-wink') %>
+                  <% end %>
+                </li>
+              </ul>
+              <% end %>
+            </dd>
+          </dl>
+        </li>
         <% end %>
+      </ol>
     </div>
-    <div class="buttons">
-        <%=link_to "/records/#{record.id}" do %>
-            <%= icon("fas", "external-link-alt") %>
-        <% end %>
-        <% if logged_in && current_user.id == record.user_id %>
-            <%= link_to "/records/#{record.id}/edit" do %>
-                <%= icon("fas", "pen") %>
-            <% end %>
-            <%= link_to "/records/#{record.id}", method: :delete, data: { confirm: "本当に削除しますか？"} do %>
-                <%= icon("fas", "trash") %>
-            <% end %>
-        <% end %>
+    <% if record.picture? %>
+    <div class="picture">
+      <%= image_tag record.picture.url %>
     </div>
+    <% end %>
+  </div>
+  <div class="buttons">
+    <%=link_to "/records/#{record.id}" do %>
+    <%= icon('fas', 'external-link-alt') %>
+    <% end %>
+    <% if logged_in && current_user.id == record.user_id %>
+    <%= link_to "/records/#{record.id}/edit" do %>
+    <%= icon('fas', 'pen') %>
+    <% end %>
+    <%= link_to "/records/#{record.id}", method: :delete, data: { confirm: "本当に削除しますか？"} do %>
+    <%= icon('fas', 'trash') %>
+    <% end %>
+    <% end %>
+  </div>
 </li>

--- a/app/views/training_record/_event_fields.html.erb
+++ b/app/views/training_record/_event_fields.html.erb
@@ -12,7 +12,6 @@
                     <td>重量</td>
                     <td>レップ数</td>
                     <td>セット数</td>
-                    <td>メインセット</td>
                 </tr>
                 <%= render 'set_datum_fields', f: i %>
             </table>

--- a/app/views/training_record/_event_fields.html.erb
+++ b/app/views/training_record/_event_fields.html.erb
@@ -1,26 +1,26 @@
 <div class="nested-fields event_fields">
-    <div class="event_item">
-        <%= link_to_remove_association f do %>
-        <%= icon("fas", "trash-alt") %>
+  <div class="event_item">
+    <%= link_to_remove_association f do %>
+    <%= icon("fas", "trash-alt") %>
+    <% end %>
+    <div id="eventItem" class="event_item_data" include="form-input-select()">
+      <%= f.collection_select :name, MenuName.all, :name, :name,:prompt => "種目を選択する" %>
+      <%= f.fields_for :set_datum do |i| %>
+      <table>
+        <tr class="titles">
+          <th></th>
+          <td>重量</td>
+          <td>レップ数</td>
+          <td>セット数</td>
+        </tr>
+        <%= render 'set_datum_fields', f: i %>
+      </table>
+      <% end %>
+      <div class="links">
+        <%= link_to_add_association f, :set_datum do %>
+        <%= icon("fas","plus-circle") %>
         <% end %>
-        <div id="eventItem" class="event_item_data" include="form-input-select()">
-            <%= f.collection_select :name, MenuName.all, :name, :name,:prompt => "種目を選択する" %>
-            <%= f.fields_for :set_datum do |i| %>
-            <table>
-                <tr class="titles">
-                    <th></th>
-                    <td>重量</td>
-                    <td>レップ数</td>
-                    <td>セット数</td>
-                </tr>
-                <%= render 'set_datum_fields', f: i %>
-            </table>
-            <% end %>
-            <div class="links">
-                <%= link_to_add_association f, :set_datum do %>
-                <%= icon("fas","plus-circle") %>
-                <% end %>
-            </div>
-        </div>
+      </div>
     </div>
+  </div>
 </div>

--- a/app/views/training_record/_set_datum_fields.html.erb
+++ b/app/views/training_record/_set_datum_fields.html.erb
@@ -13,8 +13,9 @@
         </td>
         <td>
             <%= f.check_box :main, { class: "main" } %>
+            <span class="main">main</span>
         </td>
-        <td>
+        <td class="removeIcon">
             <%= link_to_remove_association f do %>
             <%= icon("fas", "minus-circle") %>
             <% end %>

--- a/app/views/training_record/_set_datum_fields.html.erb
+++ b/app/views/training_record/_set_datum_fields.html.erb
@@ -1,23 +1,27 @@
     <tr class="nested-fields set_datum_fields row">
-        <th>
+      <th>
 
-        </th>
-        <td>
-            <%= f.number_field :weight, placeholder: "kg", "step"=>"0.5" %>
-        </td>
-        <td>
-            <%= f.number_field :rep, placeholder: "(例)8", "pattern"=>"\\d*" %>
-        </td>
-        <td>
-            <%= f.number_field :set, placeholder: "(例)3", "pattern"=>"\\d*" %>
-        </td>
-        <td>
-            <%= f.check_box :main, { class: "main" } %>
-            <span class="main">main</span>
-        </td>
-        <td class="removeIcon">
-            <%= link_to_remove_association f do %>
-            <%= icon("fas", "minus-circle") %>
-            <% end %>
-        </td>
+      </th>
+      <td>
+        <%= f.number_field :weight, placeholder: "kg", "step"=>"0.5" %>
+      </td>
+      <td>
+        <%= f.number_field :rep, placeholder: "(例)8", "pattern"=>"\\d*" %>
+      </td>
+      <td>
+        <%= f.number_field :set, placeholder: "(例)3", "pattern"=>"\\d*" %>
+      </td>
+      <td>
+        <%= f.check_box :main, { class: 'main' } %>
+        <span class="main">main</span>
+      </td>
+      <td>
+        <%= f.check_box :renewal, { class: 'new' } %>
+        <span class="new">new</span>
+      </td>
+      <td class="removeIcon">
+        <%= link_to_remove_association f do %>
+        <%= icon('fas', 'minus-circle') %>
+        <% end %>
+      </td>
     </tr>

--- a/app/views/training_record/show.html.erb
+++ b/app/views/training_record/show.html.erb
@@ -31,7 +31,9 @@
                                 <li><%= set_item.rep %>レップ</li>
                                 <li><%= set_item.set %>セット</li>
                                 <% if set_item.main %>
-                                <li class="mainMark">メインセット</li>
+                                <li class="mainMark">
+                                    <%= icon("fas", "star") %>
+                                </li>
                                 <% end %>
                             </ul>
                             <% end %>

--- a/app/views/training_record/show.html.erb
+++ b/app/views/training_record/show.html.erb
@@ -1,71 +1,76 @@
 <div class="wrapper">
-    <div class="record_detail listItemDecorated record">
-        <div class="user">
-            <% if @user.picture.present? %>
-            <%=link_to "/users/#{@user_id}" do %>
-            <%= image_tag @user.picture.url, class:"user_image" %>
-            <%= @user.name %>
-            <% end %>
-            <% else %>
-            <%= link_to "/users/#{@user_id}" do %>
-            <%= image_tag ('noicon.png'), class:"user_image" %>
-            <%= @user.name %>
-            <% end %>
-            <% end %>
-        </div>
+  <div class="record_detail listItemDecorated record">
+    <div class="user">
+      <% if @user.picture.present? %>
+      <%=link_to "/users/#{@user_id}" do %>
+      <%= image_tag @user.picture.url, class:"user_image" %>
+      <%= @user.name %>
+      <% end %>
+      <% else %>
+      <%= link_to "/users/#{@user_id}" do %>
+      <%= image_tag ('noicon.png'), class:"user_image" %>
+      <%= @user.name %>
+      <% end %>
+      <% end %>
+    </div>
 
-        <div class="comment">
-            <p><%= @record.comment %></p>
-        </div>
+    <div class="comment">
+      <p><%= @record.comment %></p>
+    </div>
 
-        <div class="set">
-            <ol>
-                <% @record.event.each do |item| %>
-                <li>
-                    <dl>
-                        <dt><%= link_to "#{item.name}", "/records/event/#{item.name}" %></dt>
-                        <dd>
-                            <% item.set_datum.each do |set_item| %>
-                            <ul class="set_list">
-                                <li><%= weight_change(set_item.weight) %>kg</li>
-                                <li><%= set_item.rep %>レップ</li>
-                                <li><%= set_item.set %>セット</li>
-                                <% if set_item.main %>
-                                <li class="mainMark">
-                                    <%= icon("fas", "star") %>
-                                </li>
-                                <% end %>
-                            </ul>
-                            <% end %>
-                        </dd>
-                    </dl>
+    <div class="set">
+      <ol>
+        <% @record.event.each do |item| %>
+        <li>
+          <dl>
+            <dt><%= link_to "#{item.name}", "/records/event/#{item.name}" %></dt>
+            <dd>
+              <% item.set_datum.each do |set_item| %>
+              <ul class="set_list">
+                <li><%= weight_change(set_item.weight) %>kg</li>
+                <li><%= set_item.rep %>レップ</li>
+                <li><%= set_item.set %>セット</li>
+                <% if set_item.main %>
+                <li class="mainMark">
+                  <%= icon('fas', 'star') %>
                 </li>
                 <% end %>
-            </ol>
-        </div>
-
-        <% if @record.picture? %>
-        <div class="picture">
-            <%= image_tag @record.picture.url %>
-        </div>
+                <% if set_item.renewal %>
+                <li class="renewalMark">
+                  <%= icon('fas', 'smile-wink') %>
+                  <% end %>
+                </li>
+              </ul>
+              <% end %>
+            </dd>
+          </dl>
+        </li>
         <% end %>
-
-        <div class="date">
-            <%= @record.created_at.to_s(:datetime) %>
-        </div>
-
-        <div class="buttons">
-            <%=link_to "/records/#{@record.id}" do %>
-            <%= icon("fas", "external-link-alt") %>
-            <% end %>
-            <% if logged_in && current_user.id == @record.user_id %>
-            <%= link_to "/records/#{@record.id}/edit" do %>
-            <%= icon("fas", "pen") %>
-            <% end %>
-            <%= link_to "/records/#{@record.id}", method: :delete, data: { confirm: "本当に削除しますか？"} do %>
-            <%= icon("fas", "trash") %>
-            <% end %>
-            <% end %>
-        </div>
+      </ol>
     </div>
+
+    <% if @record.picture? %>
+    <div class="picture">
+      <%= image_tag @record.picture.url %>
+    </div>
+    <% end %>
+
+    <div class="date">
+      <%= @record.created_at.to_s(:datetime) %>
+    </div>
+
+    <div class="buttons">
+      <%=link_to "/records/#{@record.id}" do %>
+      <%= icon("fas", "external-link-alt") %>
+      <% end %>
+      <% if logged_in && current_user.id == @record.user_id %>
+      <%= link_to "/records/#{@record.id}/edit" do %>
+      <%= icon("fas", "pen") %>
+      <% end %>
+      <%= link_to "/records/#{@record.id}", method: :delete, data: { confirm: "本当に削除しますか？"} do %>
+      <%= icon("fas", "trash") %>
+      <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/user_event/show.html.erb
+++ b/app/views/user_event/show.html.erb
@@ -1,36 +1,38 @@
 <div class="wrapper">
-    <div class="userEvent">
-        <h1><%=@user.name %>の<br class="sp"><%= @name_params %>の記録</h1>
-        <div id="chart">
-            <div v-show="loading">グラフを生成しています...</div>
-            <div v-show="!loading" class="chatwrap">
-                <div class="chart">
-                    <canvas id="myChart"></canvas>
-                </div>
-            </div>
+  <div class="userEvent">
+    <h1><%=@user.name %>の<br class="sp"><%= @name_params %>の記録</h1>
+    <div id="chart">
+      <div v-show="loading">グラフを生成しています...</div>
+      <div v-show="!loading" class="chatwrap">
+        <div class="chart">
+          <canvas id="myChart"></canvas>
         </div>
-        <ul>
-            <% @records.each do |record| %>
-            <% nameitem = record.event.where(name: @name_params).distinct %>
-            <% nameitem.each do |item| %>
-            <li class="listItemDecorated">
-                <dl>
-                    <dt><%= item.created_at.to_s(:date) %>の記録</dt>
-                    <dd>
-                        <ol>
-                            <% item.set_datum.each do |set| %>
-                            <li><%= weight_change(set.weight) %> x <%= set.rep %> x <%= set.set %></li>
-                            <% end %>
-                        </ol>
-                    </dd>
-                </dl>
-                <% end %>
-                <%=link_to "/records/#{record.id}",class:"parentRecord" do %>
-                <%=icon("fas","external-link-alt") %>
-                <% end %>
-            </li>
-            <% end %>
-        </ul>
+        <button v-on:click="updateGraph"></button>
+        <button v-on:click="displayGraph"></button>
+      </div>
     </div>
+    <ul>
+      <% @records.each do |record| %>
+      <% nameitem = record.event.where(name: @name_params).distinct %>
+      <% nameitem.each do |item| %>
+      <li class="listItemDecorated">
+        <dl>
+          <dt><%= item.created_at.to_s(:date) %>の記録</dt>
+          <dd>
+            <ol>
+              <% item.set_datum.each do |set| %>
+              <li><%= weight_change(set.weight) %> x <%= set.rep %> x <%= set.set %></li>
+              <% end %>
+            </ol>
+          </dd>
+        </dl>
+        <% end %>
+        <%=link_to "/records/#{record.id}",class:"parentRecord" do %>
+        <%=icon("fas","external-link-alt") %>
+        <% end %>
+      </li>
+      <% end %>
+    </ul>
+  </div>
 </div>
 <%= javascript_pack_tag 'ch' %>

--- a/db/migrate/20200428074503_add_renewal_to_set_datum.rb
+++ b/db/migrate/20200428074503_add_renewal_to_set_datum.rb
@@ -1,0 +1,5 @@
+class AddRenewalToSetDatum < ActiveRecord::Migration[5.2]
+  def change
+    add_column :set_data, :renewal, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_27_105636) do
+ActiveRecord::Schema.define(version: 2020_04_28_074503) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "name"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2020_04_27_105636) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "main"
+    t.boolean "renewal"
   end
 
   create_table "training_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|


### PR DESCRIPTION
#86 
対応内容は以下の通りです。  

- メインセットのマークが文字だけになっている  
→記録の表示...fontawesomeの星アイコンを使用して「メインセットであること」を示しました。  
- メインセットの表記によって画面幅によってはUIが崩れている  
→記録の表示...星アイコンで幅を取らないUIにしたので崩れないようになりました。
→記録フォーム...checkboxの左に小さく"main"と表記して範囲内に収めました。（日本語が文字化けして "???"になる事象が発生するので、一旦英語表記にしておきます）

